### PR TITLE
catch exceptions when trying to connect redis server

### DIFF
--- a/includes/dropins/redis-object-cache.php
+++ b/includes/dropins/redis-object-cache.php
@@ -1016,7 +1016,25 @@ class WP_Object_Cache {
 		} else { //tcp connection
 			$port = ! empty( $redis_server['port'] ) ? $redis_server['port'] : 6379;
 		}
-		$this->redis->connect( $redis_server['host'], $port, 1, null, 100 ); # 1s timeout, 100ms delay between reconnections
+
+		try {
+			$this->redis->connect( $redis_server['host'], $port, 1, null, 100 ); # 1s timeout, 100ms delay between reconnections
+		} catch ( RedisException $e ) {
+			// PhpRedis throws an Exception when it fails a server call.
+			// To prevent WordPress from fataling, we catch the Exception.
+			try {
+				$this->last_triggered_error = 'WP Redis: ' . $e->getMessage();
+				// Be friendly to developers debugging production servers by triggering an error
+				// @codingStandardsIgnoreStart
+				trigger_error( $this->last_triggered_error, E_USER_WARNING );
+				// @codingStandardsIgnoreEnd
+			} catch ( PHPUnit_Framework_Error_Warning $e ) {
+				// PHPUnit throws an Exception when `trigger_error()` is called.
+				// To ensure our tests (which expect Exceptions to be caught) continue to run,
+				// we catch the PHPUnit exception and inspect the RedisException message
+			}
+		}
+
 		foreach ( array( 'auth' => 'auth', 'database' => 'select' ) as $k => $method ) {
 			if ( ! isset( $redis_server[ $k ] ) ) {
 				continue;


### PR DESCRIPTION
When I try to enable the redis object cache with wrong connection informations, I got an error and site was down.

Here is the error:
> FastCGI sent in stderr: "PHP message: PHP Fatal error:  Uncaught RedisException: Connection refused in /var/www/wp-content/plugins/powered-cache/includes/dropins/redis-object-cache.php:1019

To fix this error, I called connection function in the try catch statement.

I think this is good enough for now but It would be great  to have connection control when settings save.